### PR TITLE
#131: Add network status and stats, as well as refactor out some time utilites

### DIFF
--- a/src/base_station/Makefile
+++ b/src/base_station/Makefile
@@ -1,5 +1,5 @@
 SOURCES = main.cpp controller.cpp camera_feed.cpp gui.cpp debug_console.cpp logger.cpp log_view.cpp
-HEADERS = controller.hpp camera_feed.hpp gui.hpp debug_console.hpp logger.hpp log_view.hpp
+HEADERS = controller.hpp camera_feed.hpp gui.hpp debug_console.hpp logger.hpp log_view.hpp ../util/util.hpp
 LIBRARIES = ../../bin/libnetwork.a ../../bin/libsimpleconfig.a
 CFLAGS = -std=c++14 -Wall -g -I/opt/libjpeg-turbo/include -pthread
 LFLAGS = `pkg-config --static --libs glfw3` -lGL -lX11 -ldl -L/opt/libjpeg-turbo/lib64 -l:libturbojpeg.a -L../../bin -lnetwork -lsimpleconfig

--- a/src/base_station/main.cpp
+++ b/src/base_station/main.cpp
@@ -1,5 +1,6 @@
 #include "../network/network.hpp"
 #include "../simple_config/simpleconfig.h"
+#include "../util/util.hpp"
 
 #include "camera_feed.hpp"
 #include "controller.hpp"
@@ -17,19 +18,13 @@
 #include <cstdlib>
 #include <cmath>
 
-#include <chrono>
 #include <iostream>
 #include <stack>
 #include <string>
 #include <vector>
 
-#include <iostream>
-#include <string>
-#include <vector>
-
 #include <sys/types.h>
 #include <unistd.h>
-#include <time.h>
 
 // Default angular resolution (vertices / radian) to use when drawing circles.
 constexpr float ANGULAR_RES = 10.0f;
@@ -46,11 +41,9 @@ const int16_t JOINT_DRIVE_SPEED = 50;
 
 // Send movement updates 3x per second.
 const int MOVEMENT_SEND_INTERVAL = 1000 / 20;
-// Heartbeat interval
-const int HEARTBEAT_SEND_INTERVAL = 1000 / 3;
-const int RECONNECT_INTERVAL = 1000 / 3;
-// Amount of time between heartbeats until disconnection flag is set
-const int DISCONNECT_TIMER = 5000;
+
+// Update network statistics once per second.
+const int NETWORK_STATS_INTERVAL = 1000;
 
 const int LOG_VIEW_WIDTH = 572;
 const int LOG_VIEW_HEIGHT = 458;
@@ -58,17 +51,16 @@ const int LOG_VIEW_HEIGHT = 458;
 // Network feeds.
 network::Feed r_feed, bs_feed;
 
+struct {
+    float r_tp = 0;
+    float bs_tp = 0;
+    float t_tp = 0;
+} last_network_stats;
+
+// Clock!
+util::Clock global_clock;
+
 unsigned int map_texture_id;
-
-// Save the start time so we can use get_ticks.
-std::chrono::high_resolution_clock::time_point start_time;
-
-unsigned int get_ticks()
-{
-    auto now = std::chrono::high_resolution_clock::now();
-
-    return (unsigned int)std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count();
-}
 
 std::vector<std::string> split_by_spaces(std::string s) {
 	std::vector<std::string> strings;
@@ -226,13 +218,25 @@ void do_info_panel(gui::Layout* layout, gui::Font* font) {
 
 	gui::do_solid_rect(layout, w, h, 68.0f / 255.0f, 68.0f / 255.0f, 68.0f / 255.0f);
 
-	char bandwidth_buffer[50];
-    //TODO: Update this with "bandwidth" (maybe call it network usage?
-	sprintf(bandwidth_buffer, "Network bandwidth: %.3fM/s", 69.0f);
+    char rover_network_status_buffer[50];
+    sprintf(rover_network_status_buffer, "Rover net status: %s",
+        r_feed.status == network::FeedStatus::ALIVE ? "alive" : "dead");
+
+	if (r_feed.status == network::FeedStatus::ALIVE) {
+        glColor4f(0.0f, 1.0f, 0.0f, 1.0f);
+    } else {
+        glColor4f(1.0f, 0.0f, 0.0f, 1.0f);
+    }
+	gui::draw_text(font, rover_network_status_buffer, x + 5, y + 5, 15);
+
+	char bandwidth_buffer[100];
+	sprintf(bandwidth_buffer, "Net thpt (r/bs/t): %.2f/%.2f/%.2f MiB/s", 
+        last_network_stats.r_tp,
+        last_network_stats.bs_tp,
+        last_network_stats.t_tp);
 
 	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-	gui::draw_text(font, bandwidth_buffer, x + 5, y + 5, 20);
-
+	gui::draw_text(font, bandwidth_buffer, x + 5, y + 20 + 5, 15);
 
 	time_t current_time;
 	time(&current_time);
@@ -514,15 +518,14 @@ float smooth_rover_input(float value) {
 
 int main()
 {
+    util::Clock::init(&global_clock);
+
 	logger::register_handler(stderr_handler);
 
 	gui::debug_console::set_callback(command_callback);
 
 	// Load config.
 	Config config = load_config("res/bs.sconfig");
-
-    // Start the timer.
-    start_time = std::chrono::high_resolution_clock::now();
 
     // Init GLFW.
     if (!glfwInit()) {
@@ -586,7 +589,7 @@ int main()
 
     // Initialize network functionality.
     {
-        auto err = network::init_publisher(config.base_station_multicast_group, config.base_station_port, &bs_feed);
+        auto err = network::init(&bs_feed, network::FeedType::OUT, config.base_station_multicast_group, config.base_station_port, &global_clock);
         if (err != network::Error::OK) {
 			logger::log(logger::ERROR, "Failed to init base station feed: %s", network::get_error_string(err));
             return 1;
@@ -596,7 +599,7 @@ int main()
     }
 
     {
-        auto err = network::init_subscriber(config.rover_multicast_group, config.rover_port, &r_feed);
+        auto err = network::init(&r_feed, network::FeedType::IN, config.rover_multicast_group, config.rover_port, &global_clock);
         if (err != network::Error::OK) {
 			logger::log(logger::ERROR, "Failed to init rover feed: %s", network::get_error_string(err));
             return 1;
@@ -605,10 +608,13 @@ int main()
         logger::log(logger::INFO, "Network: subscribed to rover feed on %s:%d", config.rover_multicast_group, config.rover_port);
     }
 
-    // Keep track of when we last sent movement and heartbeat info.
-    unsigned int last_movement_send_time = 0;
-    // Last time heartbeat was sent
-    unsigned int last_heartbeat_send_time = 0;
+    // Keep track of when we last sent movement info.
+    util::Timer movement_send_timer;
+    util::Timer::init(&movement_send_timer, MOVEMENT_SEND_INTERVAL, &global_clock);
+
+    // Grab network stats every second.
+    util::Timer network_stats_timer;
+    util::Timer::init(&network_stats_timer, NETWORK_STATS_INTERVAL, &global_clock);
 
     // Init the controller.
 	// TODO: QUERY /sys/class/input/js1/device/id/{vendor,product} TO FIND THE RIGHT CONTROLLER.
@@ -663,8 +669,6 @@ int main()
 			if (help_menu_up) help_menu_up = false;
 		}
 
-        // TODO: Do network usage update here!
-
         // Handle incoming network messages from the rover feed.
         network::IncomingMessage message;
         while (true) {
@@ -718,9 +722,17 @@ int main()
             }
         }
 
-        // Reset heartbeat send time
-        if (get_ticks() - last_heartbeat_send_time >= HEARTBEAT_SEND_INTERVAL) {
-            last_heartbeat_send_time = get_ticks();
+        // Update network stuff.
+        network::update_status(&r_feed);
+        network::update_status(&bs_feed);
+
+        if (network_stats_timer.ready()) {
+            last_network_stats.r_tp = (float)r_feed.bytes_transferred / ((float) NETWORK_STATS_INTERVAL * 1000.0f);
+            last_network_stats.bs_tp = (float)bs_feed.bytes_transferred / ((float) NETWORK_STATS_INTERVAL * 1000.0f);
+            last_network_stats.t_tp = last_network_stats.r_tp + last_network_stats.bs_tp;
+
+            r_feed.bytes_transferred = 0;
+            bs_feed.bytes_transferred = 0;
         }
 
         if (controller_loaded) {
@@ -801,9 +813,7 @@ int main()
 			}
 		}
 
-		if (get_ticks() - last_movement_send_time >= MOVEMENT_SEND_INTERVAL) {
-			last_movement_send_time = get_ticks();
-
+		if (movement_send_timer.ready()) {
 			// printf("sending movement with %d, %d\n", last_movement_message.left, last_movement_message.right);
 
             network::publish(&bs_feed, &last_movement_message);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -201,66 +201,93 @@ Buffer get_outgoing_buffer(Feed* feed) {
 // Feed Management
 //
 
-Error init_subscriber(const char* group, uint16_t port, Feed* out_feed) {
+Error init(Feed* out_feed, FeedType type, const char* group, uint16_t port, util::Clock* clock) {
     int sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock_fd == -1) {
         return Error::SOCKET;
     }
-    out_feed->socket_fd = sock_fd;
 
     uint8_t ttl = MULTICAST_TTL;
 	setsockopt(sock_fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl));
 
-    // Bind to the correct port.
-    struct sockaddr_in bind_addr{};
-    bind_addr.sin_family = AF_INET;
-    bind_addr.sin_port = htobe16(port);
-    bind_addr.sin_addr.s_addr = htobe32(INADDR_ANY);
+    switch (type) {
+    case FeedType::IN: {
+        // Bind to the correct port.
+        struct sockaddr_in bind_addr{};
+        bind_addr.sin_family = AF_INET;
+        bind_addr.sin_port = htobe16(port);
+        bind_addr.sin_addr.s_addr = htobe32(INADDR_ANY);
 
-    if (bind(sock_fd, (struct sockaddr*) &bind_addr, sizeof(bind_addr)) == -1) {
-        ::close(sock_fd);
-        return Error::BIND;
+        if (bind(sock_fd, (struct sockaddr*) &bind_addr, sizeof(bind_addr)) == -1) {
+            ::close(sock_fd);
+            return Error::BIND;
+        }
+
+        // Join the multicast group.
+        struct ip_mreq mreq;
+        mreq.imr_multiaddr.s_addr = inet_addr(group);
+        mreq.imr_interface.s_addr = htobe32(INADDR_ANY);
+        
+        if (setsockopt(sock_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
+            ::close(sock_fd);
+            return Error::MULTICAST_JOIN;    
+        }
+
+        break;
+    }
+    case FeedType::OUT: {
+        // Connect so that future writes on this socket all go to the right place.
+        struct sockaddr_in connect_addr{};
+        connect_addr.sin_family = AF_INET;
+        connect_addr.sin_port = htobe16((short)port);
+        connect_addr.sin_addr.s_addr = inet_addr(group);
+
+        if (connect(sock_fd, (struct sockaddr*)&connect_addr, sizeof(connect_addr)) == -1) {
+            ::close(sock_fd);
+            return Error::CONNECT;
+        }
+
+        break;
+    }
     }
 
-    // Join the multicast group.
-    struct ip_mreq mreq;
-    mreq.imr_multiaddr.s_addr = inet_addr(group);
-    mreq.imr_interface.s_addr = htobe32(INADDR_ANY);
-    
-    if (setsockopt(sock_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
-        ::close(sock_fd);
-        return Error::MULTICAST_JOIN;    
-    }
-
+    out_feed->socket_fd = sock_fd;
     out_feed->memory_pool.init(MAX_RAW_PACKET_SIZE, 64);
     out_feed->bytes_transferred = 0;
+    out_feed->clock = clock;
+    out_feed->last_active_time = 0;
+    out_feed->status = FeedStatus::DEAD;
 
     return Error::OK;
 }
 
-Error init_publisher(const char* group, uint16_t port, Feed* out_feed) {
-    int sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sock_fd == -1) {
-        return Error::SOCKET;
+Error update_status(Feed* feed) {
+    auto now = feed->clock->get_millis();
+
+    switch (feed->type) {
+    case FeedType::IN: {
+        if (now - feed->last_active_time >= MAX_HEARTBEAT_WAIT_TIME) {
+            feed->status = FeedStatus::DEAD;
+        } else {
+            feed->status = FeedStatus::ALIVE;    
+        }
+
+        return Error::OK;
+    }
+    case FeedType::OUT: {
+        if (now - feed->last_active_time >= MAX_IDLE_TIME) {
+            HeartbeatMessage hb;
+            
+            return publish(feed, &hb);
+        } else {
+            feed->status = FeedStatus::ALIVE;
+        }
+
+        return Error::OK;
+    }
     }
 
-    uint8_t ttl = MULTICAST_TTL;
-	setsockopt(sock_fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl));
-
-    out_feed->socket_fd = sock_fd;
-    struct sockaddr_in connect_addr{};
-    connect_addr.sin_family = AF_INET;
-    connect_addr.sin_port = htobe16((short)port);
-    connect_addr.sin_addr.s_addr = inet_addr(group);
-
-    if (connect(sock_fd, (struct sockaddr*)&connect_addr, sizeof(connect_addr)) == -1) {
-        ::close(sock_fd);
-        return Error::CONNECT;
-    }
-
-    out_feed->memory_pool.init(MAX_RAW_PACKET_SIZE, 64);
-    out_feed->bytes_transferred = 0;
-
+    // I guess we'll do this...
     return Error::OK;
 }
 
@@ -311,6 +338,8 @@ Error receive(Feed* feed, IncomingMessage* out_message) {
     out_message->type = (MessageType) message_type;
     out_message->buffer = buffer;
 
+    feed->last_active_time = feed->clock->get_millis();
+
     return Error::OK;
 }
 
@@ -337,6 +366,9 @@ Error send(Feed* feed, MessageType type, Buffer buffer) {
 
     // Discard buffer.
     feed->memory_pool.free(buffer.data);
+
+    feed->status = FeedStatus::ALIVE;
+    feed->last_active_time = feed->clock->get_millis();
 
     return Error::OK;
 }

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "../util/util.hpp"
+
 #include "memory.hpp"
 
 namespace network {
@@ -22,8 +24,11 @@ const int MAX_RAW_PACKET_SIZE = 1500; // Use Ethernet MTU.
 const int HEADER_SIZE = 1 + 1 + 2; 
 const int MAX_MESSAGE_SIZE = MAX_RAW_PACKET_SIZE - HEADER_SIZE;
 
-const int MAX_IDLE_TIME = 2000; // In ms.
-const int MAX_HEARTBEAT_WAIT_TIME = 1000;
+// The time a sending feed will wait with no sending before sending a heartbeat.
+const int MAX_IDLE_TIME = 1000; // In ms.
+// The max time a receiving feed will wait for incoming packets before declaring
+// a feed to be DEAD.
+const int MAX_HEARTBEAT_WAIT_TIME = 2000;
 
 // TODO: If things aren't getting through, increase this number to 32.
 const uint8_t MULTICAST_TTL = 1;
@@ -56,16 +61,32 @@ const char* get_error_string(Error error);
 // Feed Management
 //
 
-struct Feed {
-   int socket_fd;
-
-   MemoryPool memory_pool;
-
-   int bytes_transferred;
+enum class FeedStatus {
+    ALIVE,
+    DEAD
 };
 
-Error init_publisher(const char* group, uint16_t port, Feed* out_feed);
-Error init_subscriber(const char* group, uint16_t port, Feed* out_feed);
+enum class FeedType {
+    IN,
+    OUT
+};
+
+struct Feed {
+    FeedType type;    
+    int socket_fd;
+
+    MemoryPool memory_pool;
+
+    util::Clock* clock;
+
+    int bytes_transferred;
+    FeedStatus status;
+    uint32_t last_active_time;
+};
+
+Error init(Feed* out_feed, FeedType type, const char* group, uint16_t port, util::Clock* clock);
+
+Error update_status(Feed* feed);
 
 void close(Feed* feed);
 
@@ -257,6 +278,18 @@ struct LocationMessage {
     bool has_fix;
     float latitude;
     float longitude;
+
+    void serialize(Buffer* buffer) {
+        network::serialize(buffer, this->has_fix);
+        network::serialize(buffer, this->latitude);
+        network::serialize(buffer, this->longitude);
+    }
+
+    void deserialize(Buffer* buffer) {
+        network::deserialize(buffer, &(this->has_fix));
+        network::deserialize(buffer, &(this->latitude));
+        network::deserialize(buffer, &(this->longitude));
+    }
 };
 
 //

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -60,6 +60,8 @@ struct Feed {
    int socket_fd;
 
    MemoryPool memory_pool;
+
+   int bytes_transferred;
 };
 
 Error init_publisher(const char* group, uint16_t port, Feed* out_feed);

--- a/src/rover/Makefile
+++ b/src/rover/Makefile
@@ -1,5 +1,5 @@
 SOURCES = main.cpp camera.cpp 
-HEADERS = camera.hpp autonomy.hpp suspension.hpp lidar.hpp imu.hpp gps.hpp
+HEADERS = camera.hpp autonomy.hpp suspension.hpp lidar.hpp imu.hpp gps.hpp ../util/util.hpp
 LIBRARIES = ../../bin/libnetwork.a ../../bin/libsimpleconfig.a
 LFLAGS = -L../../bin -lnetwork -L/opt/libjpeg-turbo/lib64 -l:libturbojpeg.a -lsimpleconfig
 CFLAGS = -pthread -Wall -std=c++11 -g -I/opt/libjpeg-turbo/include

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -1,0 +1,57 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+#include <time.h>
+#include <stdint.h>
+
+namespace util {
+
+struct Clock {
+    uint32_t start_ms;
+
+    uint32_t get_millis() {
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        
+        uint32_t ms = (uint32_t)now.tv_sec * 1000;
+        ms += (uint32_t)now.tv_nsec / 1000000;
+
+        return ms - start_ms;
+    }
+
+    static void init(Clock* clock) {
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+
+        clock->start_ms = (uint32_t)now.tv_sec * 1000;
+        clock->start_ms += (uint32_t)now.tv_nsec / 1000000;
+    }
+};
+
+struct Timer {
+    uint32_t interval;
+    uint32_t last;
+    Clock* clock;
+
+    bool ready() {
+        auto now = clock->get_millis();
+
+        if (now - last >= interval) {
+            last = now;
+            return true;
+        }
+
+        return false;
+    }
+
+    static void init(Timer* timer, uint32_t interval, Clock* clock) {
+        timer->interval = interval;
+        timer->clock = clock;
+
+        timer->last = 0;
+    }
+};
+
+} // namespace util
+
+#endif


### PR DESCRIPTION
- Refactored network library to distinguish between in and out feeds at runtime.
- Added sent/received byte counting to network library.
- Added an incoming feed status query/update system which includes sending heartbeats when a publishing feed is idle.
- Added a shared util header that currently contains some helpful time abstractions.
- Removed previous time code in r/bs and integrated new util stuff (much better).
- Updated network API calls in r/bs and added a call every loop which updates feed statuses.
- Added network throughput and rover feed status displays to the base station GUI.