### PR TITLE
Fix #133 log view overflow

### DIFF
--- a/src/base_station/gui.cpp
+++ b/src/base_station/gui.cpp
@@ -139,6 +139,24 @@ int text_width(Font *font, const char *text, int height)
     return (int)((float)total_width * scale);
 }
 
+// Returns the index of the last character that can fit on a line of the given width.
+int text_last_index_that_can_fit(Font* font, const char* text, float width, int height) {
+    // We want to make sure our width is correctly reported.
+    float scale = (float)height / (float)font->max_height;
+
+    float x = 0, y = 0;
+    int i;
+    for (i = 0; text[i]; i++) {
+        stbtt_aligned_quad q;
+        stbtt_GetBakedQuad(font->baked_chars, 1024, 1024, text[i] - 32, &x, &y, &q, 1);
+
+        float line_width = q.x1 * scale;
+        if (line_width > width) return i - 1;
+    }
+
+    return i - 1;
+}
+
 // Draws the string with the given font at the given height.
 void draw_text(Font *font, const char *text, int x, int y, float height)
 {

--- a/src/base_station/gui.hpp
+++ b/src/base_station/gui.hpp
@@ -52,6 +52,9 @@ bool load_font(Font *font, const char *file_name, int size);
 // font at the given height.
 int text_width(Font *font, const char *text, int height);
 
+// Returns the index of the last character that can fit on a line of the given width.
+int text_last_index_that_can_fit(Font* font, const char* text, float width, int height);
+
 void draw_text(Font *font, const char *text, int x, int y, float height);
 
 struct LayoutState

--- a/src/base_station/log_view.cpp
+++ b/src/base_station/log_view.cpp
@@ -36,31 +36,18 @@ static void removeOldMessages()
     }
 }
 
-void calc_sizing(gui::Font* font, int width, int height) {
-	chars_per_line = width / gui::text_width(font, "m", FONT_SIZE);
-	num_lines = (height + PADDING) / (FONT_SIZE + PADDING);
-}
-
-void print(std::string m, float r, float g, float b, float a)
+void print(gui::Font* font, int width, std::string m, float r, float g, float b, float a)
 {
     while (m.length() > 0) {
-        if (m.length() <= chars_per_line) {
-            logMessages.push_back(m);
-            red.push_back(r);
-            green.push_back(g);
-            blue.push_back(b);
-            alpha.push_back(a);
+        int idx = gui::text_last_index_that_can_fit(font, m.c_str(), width, FONT_SIZE);
 
-            break;
-        } else {
-            logMessages.push_back(m.substr(0, chars_per_line));
-            red.push_back(r);
-            green.push_back(g);
-            blue.push_back(b);
-            alpha.push_back(a);
-	
-            m.erase(0, chars_per_line);
-        }
+        logMessages.push_back(m.substr(0, idx + 1));
+        red.push_back(r);
+        green.push_back(g);
+        blue.push_back(b);
+        alpha.push_back(a);
+
+        m.erase(0, idx + 1);
     }
    
     removeOldMessages();

--- a/src/base_station/log_view.hpp
+++ b/src/base_station/log_view.hpp
@@ -5,9 +5,7 @@
 namespace gui {
 namespace log_view {
 
-void print(std::string m, float r, float g, float b, float a);
-
-void calc_sizing(gui::Font* font, int width, int height);
+void print(gui::Font* font, int width, std::string m, float r, float g, float b, float a);
 
 void moveUpOne();
 void moveDownOne();

--- a/src/base_station/main.cpp
+++ b/src/base_station/main.cpp
@@ -59,6 +59,7 @@ const int LOG_VIEW_HEIGHT = 458;
 network::Feed r_feed, bs_feed;
 
 unsigned int map_texture_id;
+gui::Font global_font;
 
 // Save the start time so we can use get_ticks.
 std::chrono::high_resolution_clock::time_point start_time;
@@ -66,7 +67,6 @@ std::chrono::high_resolution_clock::time_point start_time;
 unsigned int get_ticks()
 {
     auto now = std::chrono::high_resolution_clock::now();
-
     return (unsigned int)std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count();
 }
 
@@ -160,7 +160,7 @@ void log_view_handler(logger::Level level, std::string message) {
 
 	std::string full_string = std::string(time_string_buffer) + message;
 
-	gui::log_view::print(full_string, r, g, b, a);
+	gui::log_view::print(&global_font, LOG_VIEW_WIDTH, full_string, r, g, b, a);
 }
 
 struct Config
@@ -563,17 +563,16 @@ int main()
     // Initial setup for GUI here so that network errors are printed to log view.
 	map_texture_id = gui::load_texture("res/binghamton.jpg");
 
+    // Load this down here so that sizing is correct.
     gui::Font font;
     bool loaded_font = gui::load_font(&font, "res/FiraMono-Regular.ttf", 100);
     if (!loaded_font) {
 		logger::log(logger::ERROR, "Failed to load font!");
         return 1;
     }
+    // TODO: Fix this hack (for the log view handler) and clean up globals in general.
+    global_font = font;
 
-	gui::log_view::calc_sizing(&font, LOG_VIEW_WIDTH, LOG_VIEW_HEIGHT);
-
-    // Load this down here so that sizing is correct.
-    // TODO: The sizing is not correct... lines are going off the right side!
 	logger::register_handler(log_view_handler);
 
     // Initialize camera stuff.


### PR DESCRIPTION
Fixed overflow of characters beyond the edge of the log view by sliding along a string and pretending to render it, making note of sizing info as we go. Then once we cross the total view width, the string is segmented such that the first part fits on one line.