### PR TITLE
#190: Fixed jpeg_quality debug command

### DIFF
--- a/src/base_station/debug_console.cpp
+++ b/src/base_station/debug_console.cpp
@@ -157,7 +157,7 @@ void command_callback(std::string command, Session *bs_session) {
                     //TODO: Fix this design hack, currently using shared_feeds to get the rover_feed established in main
                     if (shared_feeds::bs_feed != NULL){
                         network::CameraControlMessage message = {
-                            network::CameraControlMessage::Setting::GREYSCALE, // setting
+                            network::CameraControlMessage::Setting::JPEG_QUALITY, // setting
                             static_cast<uint8_t>(value) //jpegQuality
                         };
                         network::publish(shared_feeds::bs_feed, &message);


### PR DESCRIPTION
Command now successfully changes the jpeg_quality

Possible bug:

- Setting the jpeg_quality above 96 will cause errors when decoding the file at the base station. Probable cause: Picture becomes too large for the buffer assigned to it on the network